### PR TITLE
Fix token auth to /run and add login for other endpoints

### DIFF
--- a/saltstack/client.go
+++ b/saltstack/client.go
@@ -28,8 +28,20 @@ type Config struct {
 }
 
 type Client struct {
-	Config Config
-	Client *http.Client
+	Config       Config
+	Client       *http.Client
+	sessionToken string
+}
+
+type LoginReadResult struct {
+	Return []struct {
+		Token  string   `json:"token"`
+		Expire string   `json:"expire"`
+		Start  string   `json:"start"`
+		User   string   `json:"user"`
+		Eauth  string   `json:"eauth"`
+		Perms  []string `json:"perms"`
+	} `json:"return"`
 }
 
 func NewClient(config Config) (*Client, error) {
@@ -69,12 +81,79 @@ func NewClient(config Config) (*Client, error) {
 	return &c, nil
 }
 
+func (c *Client) Login() error {
+	if c.sessionToken != "" {
+		// We are already logged in and already have a session token
+		return nil
+	}
+
+	if c.Config.UseToken {
+		return fmt.Errorf("Unable to login when configured to use a token. Should configure username/password when trying to login")
+	}
+
+	reqData := map[string]interface{}{
+		"username": c.Config.Username,
+		"password": c.Config.Password,
+		"eauth":    c.Config.Eauth,
+	}
+
+	reqBody, err := convertToJSONString(reqData)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s://%s:%s/login", c.Config.Scheme, c.Config.Host, strconv.Itoa(c.Config.Port))
+	req, err := http.NewRequest("GET", url, bytes.NewBuffer([]byte(reqBody)))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf(resp.Status)
+	}
+
+	var rd LoginReadResult
+	err = parseResponseBody(resp, &rd)
+	if err != nil {
+		return err
+	}
+
+	if len(rd.Return) == 0 {
+		return fmt.Errorf("Empty return from API while trying to login")
+	}
+	c.sessionToken = rd.Return[0].Token
+	return nil
+}
+
+func (c *Client) getSessionToken() (string, error) {
+	if c.sessionToken == "" {
+		// We need to login
+		if err := c.Login(); err != nil {
+			return "", err
+		}
+	}
+
+	return c.sessionToken, nil
+}
+
 func (c *Client) Post(uri string, data map[string]interface{}) (*http.Response, error) {
 	reqData := make(map[string]interface{})
 
 	url := fmt.Sprintf("%s://%s:%s%s", c.Config.Scheme, c.Config.Host, strconv.Itoa(c.Config.Port), uri)
 
-	if !c.Config.UseToken {
+	if c.Config.UseToken {
+		if uri == "/run" {
+			reqData["token"] = c.Config.Token
+		}
+	} else {
 		reqData["username"] = c.Config.Username
 		reqData["password"] = c.Config.Password
 		reqData["eauth"] = c.Config.Eauth
@@ -95,8 +174,12 @@ func (c *Client) Post(uri string, data map[string]interface{}) (*http.Response, 
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	if c.Config.UseToken {
-		req.Header.Set("X-Auth-Token", c.Config.Token)
+	if c.Config.UseToken && uri != "/run" {
+		var sessionToken string
+		if sessionToken, err = c.getSessionToken(); err != nil {
+			return nil, err
+		}
+		req.Header.Set("X-Auth-Token", sessionToken)
 	}
 
 	resp, err := c.Client.Do(req)


### PR DESCRIPTION
According to [salt API documentation](https://docs.saltproject.io/en/latest/ref/netapi/all/salt.netapi.rest_cherrypy.html#run) the `/run` endpoint bypasses normal authentication and so doesn't take into account the `X-Auth-Token` header with a session token.

This is confirmed by [this comment](https://github.com/saltstack/salt/issues/63815#issuecomment-1458550833) in a GH issue

It only handles an eauth token generated by [mk_token](https://docs.saltproject.io/en/latest/ref/runners/all/salt.runners.auth.html#salt.runners.auth.mk_token)

So currently token auth cannot work with the saltstack terraform provider

This PR fixes that behaviour by sending configured eauth token in request data when calling `/run` endpoint and add handling of login through `/login` endpoint and session tokens for other endpoints for later use (only working when authenticating with username & password as you cannot login with an eauth token)