### PR TITLE
Allow file external auth type 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ description: |-
 ### Optional
 
 - `debug` (Boolean) Run provider in DEBUG mode. Defaults to `false`
-- `eauth` (String) Salt Master API External Authentication system. Currently supports: `pam`, `sharedsecret`. Reference: https://docs.saltproject.io/en/latest/topics/eauth/index.html. Defaults to `pam`
+- `eauth` (String) Salt Master API External Authentication system. Currently supports: `pam`, `file`, `sharedsecret`. Reference: https://docs.saltproject.io/en/latest/topics/eauth/index.html. Defaults to `pam`
 - `scheme` (String) Connection scheme. Can be http or https. Defaults to `https`.
 - `ssl_skip_verify` (Boolean) Skip SSL verification. Defaults to `false`
 - `token` (String) Authentication token if `use_token` is true.

--- a/saltstack/client.go
+++ b/saltstack/client.go
@@ -45,7 +45,7 @@ type LoginReadResult struct {
 }
 
 func NewClient(config Config) (*Client, error) {
-	supportedAuthTypesKeys := [...]string{"pam", "sharedsecret"}
+	supportedAuthTypesKeys := [...]string{"pam", "file", "sharedsecret"}
 
 	supportedAuthTypes := map[string]bool{}
 	for _, t := range supportedAuthTypesKeys {

--- a/saltstack/client_test.go
+++ b/saltstack/client_test.go
@@ -20,6 +20,20 @@ func TestValidClientWithAllRequiredConfig_pam(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestValidClientWithAllRequiredConfig_file(t *testing.T) {
+	config := Config{
+		Host:     "localhost",
+		Port:     8000,
+		Username: "username",
+		Password: "password",
+		Eauth:    "file",
+	}
+
+	client, err := NewClient(config)
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+}
+
 func TestValidClientWithAllRequiredConfig_sharedsecret(t *testing.T) {
 	config := Config{
 		Host:     "localhost",

--- a/saltstack/provider.go
+++ b/saltstack/provider.go
@@ -46,7 +46,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SALTSTACK_EAUTH", "pam"),
-				Description: "Salt Master API External Authentication system. Currently supports: `pam`, `sharedsecret`. Reference: https://docs.saltproject.io/en/latest/topics/eauth/index.html. Defaults to `pam`",
+				Description: "Salt Master API External Authentication system. Currently supports: `pam`, `file`, `sharedsecret`. Reference: https://docs.saltproject.io/en/latest/topics/eauth/index.html. Defaults to `pam`",
 			},
 			"use_token": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
Allow authentication with [file](https://docs.saltproject.io/en/latest/ref/auth/all/salt.auth.file.html) external auth plugin.