### PR TITLE
Add missing force property to minion_accepted_keypair

### DIFF
--- a/docs/resources/minion_key_pair.md
+++ b/docs/resources/minion_key_pair.md
@@ -21,6 +21,7 @@ description: |-
 
 ### Optional
 
+- `force` (Boolean) If set to True, it will overwrite existing keys for the same ID.
 - `key_size` (Number) The size of the key pair to generate. The size must be 2048, which is the default, or greater. If set to a value less than 2048, the key size will be rounded up to 2048.
 
 ### Read-Only

--- a/docs/resources/minion_key_pair.md
+++ b/docs/resources/minion_key_pair.md
@@ -21,7 +21,7 @@ description: |-
 
 ### Optional
 
-- `force` (Boolean) If set to True, it will overwrite existing keys for the same ID.
+- `force` (Boolean) If set to True, it will overwrite existing keys for the same ID. A previously accepted key will be overwritten and will result in the minion being unable to connect.
 - `key_size` (Number) The size of the key pair to generate. The size must be 2048, which is the default, or greater. If set to a value less than 2048, the key size will be rounded up to 2048.
 
 ### Read-Only

--- a/saltstack/resource_minion_accepted_key_pair.go
+++ b/saltstack/resource_minion_accepted_key_pair.go
@@ -64,6 +64,13 @@ func resourceMinionAcceptedKeyPair() *schema.Resource {
 				Default:     2048,
 				ForceNew:    true,
 			},
+			"force": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "If set to True, it will overwrite existing keys for the same ID.",
+				Default:     false,
+				ForceNew:    true,
+			},
 			"private_key": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -90,12 +97,14 @@ func resourceMinionAcceptedKeyPairCreate(ctx context.Context, d *schema.Resource
 
 	minionId := d.Get("minion_id").(string)
 	keySize := d.Get("key_size").(int)
+	force := d.Get("force").(bool)
 
 	reqData := map[string]interface{}{
 		"client":  "wheel",
 		"fun":     "key.gen_accept",
 		"id_":     minionId,
 		"keysize": keySize,
+		"force":   force,
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("Creating key pair for minion %s", minionId), nil)

--- a/saltstack/resource_minion_accepted_key_pair.go
+++ b/saltstack/resource_minion_accepted_key_pair.go
@@ -67,7 +67,7 @@ func resourceMinionAcceptedKeyPair() *schema.Resource {
 			"force": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "If set to True, it will overwrite existing keys for the same ID.",
+				Description: "If set to True, it will overwrite existing keys for the same ID. A previously accepted key will be overwritten and will result in the minion being unable to connect.",
 				Default:     false,
 				ForceNew:    true,
 			},

--- a/saltstack/resource_minion_accepted_key_pair_test.go
+++ b/saltstack/resource_minion_accepted_key_pair_test.go
@@ -2,6 +2,7 @@ package saltstack
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -31,6 +32,40 @@ func TestAccSaltstackMinionKeyPair_basic(t *testing.T) {
 	})
 }
 
+func TestAccSaltstackMinionKeyPair_overwrite(t *testing.T) {
+	minionId := "test-1.domain.com"
+	keySize := 2048
+	resourceName := "saltstack_minion_key_pair.test"
+	resourceNameForced := "saltstack_minion_key_pair.forced"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSaltstackMinionKeyPairDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckSaltstackMinionKeyPairConfigBasic(minionId, keySize),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSaltstackMinionKeyPairExists(resourceName),
+					testAccCheckSaltstackMinionPrivateKey(resourceName),
+					testAccCheckSaltstackMinionPublicKey(resourceName),
+				),
+			},
+			{
+				Config: strings.Join([]string{
+					testAccCheckSaltstackMinionKeyPairConfigBasic(minionId, keySize),
+					testAccCheckSaltstackMinionKeyPairConfigForced(minionId, keySize, true),
+				}, "\n"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSaltstackMinionKeyPairExists(resourceNameForced),
+					testAccCheckSaltstackMinionPrivateKey(resourceNameForced),
+					testAccCheckSaltstackMinionPublicKey(resourceNameForced),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckSaltstackMinionKeyPairConfigBasic(minion_id string, key_size int) string {
 	return fmt.Sprintf(`
 	resource saltstack_minion_key_pair test {
@@ -38,6 +73,16 @@ func testAccCheckSaltstackMinionKeyPairConfigBasic(minion_id string, key_size in
 		key_size = %d
 	}
 	`, minion_id, key_size)
+}
+
+func testAccCheckSaltstackMinionKeyPairConfigForced(minion_id string, key_size int, force bool) string {
+	return fmt.Sprintf(`
+    resource saltstack_minion_key_pair forced {
+		minion_id = "%s"
+		key_size = %d
+		force = %t
+	}
+	`, minion_id, key_size, force)
 }
 
 func testAccCheckSaltstackMinionKeyPairExists(resourceName string) resource.TestCheckFunc {


### PR DESCRIPTION
The force property had been omitted from the initial implementation.
This change adds the missing property for the resource to match the underlying `wheel.key.gen_accepted` API fully.